### PR TITLE
Fix network config templating

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -120,7 +120,7 @@
   when: cloud_localds.config_template is defined
 
 - name: Create net_config.yml based on cloud_localds.network_config
-  copy:
+  template:
     src: "{{ cloud_localds.network_config_template }}"
     dest: "{{ _cloudinit_net_config_yml }}"
     owner: "{{ cloud_localds.owner | default('0') }}"


### PR DESCRIPTION
When `network_config_template` is used, it just copies the `files/debian/debian_network.j2` file as `{{ dest }}_net_config.yml` without variable substitution. This happens because we are using `copy` module instead of `template` module here in [`Create net_config.yml based on cloud_localds.network_config`](https://github.com/stafwag/ansible-role-cloud_localds/blob/main/tasks/main.yml#L123) task. 

For the file `files/debian/debian_network.j2` with contains:

```
{% set cloud_config = cloud_localds.cloud_config %}
network:
  version: 2
  ethernets:
{% for interface in cloud_config.network.ethernets.interfaces %}
    {{ interface }}:
{% endfor %}
```
and variables:

```
cloud_config:
  ethernets:
    interfaces:
      enp1s0:
      enp3s0:
```

Currently, it creates `{{ dest }}_net_config.yml` with:

```
{% set cloud_config = cloud_localds.cloud_config %}
network:
  version: 2
  ethernets:
{% for interface in cloud_config.network.ethernets.interfaces %}
    {{ interface }}:
{% endfor %}
```

With the fix, it creates `{{ dest }}_net_config.yml` with:

```
network:
  version: 2
  ethernets:
      enp1s0:
      enp3s0:
```
