### PR TITLE
11 execute installation tasks only once

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,14 +1,4 @@
 ---
-- name: Set OS related variables
-  ansible.builtin.include_vars: "{{ _install_vars }}"
-  with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
-    - "defaults.yml"
-  loop_control:
-    loop_var: _install_vars
-
 - name: Install packages
   ansible.builtin.package:
     name: "{{ _pkg }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,9 @@
 ---
+- name: Load vars (Install)
+  ansible.builtin.include_tasks: load_vars.yml
+  when:
+    - _pkg is undefined
+
 - name: Install packages
   ansible.builtin.package:
     name: "{{ _pkg }}"

--- a/tasks/load_vars.yml
+++ b/tasks/load_vars.yml
@@ -1,0 +1,10 @@
+---
+- name: Set OS related variables
+  ansible.builtin.include_vars: "{{ _vars }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_os_family }}.yml"
+    - "defaults.yml"
+  loop_control:
+    loop_var: _vars

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,4 @@
 ---
-- name: Set OS related variables
-  ansible.builtin.include_vars: "{{ _vars }}"
-  with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
-    - "defaults.yml"
-  loop_control:
-    loop_var: _vars
-
 - name: Display the cloud_localds variable
   ansible.builtin.debug:
     var:
@@ -16,6 +6,9 @@
   tags:
     - never
     - debug
+
+- name: Load vars
+  ansible.builtin.include_tasks: load_vars.yml
 
 - name: Install the cloud image util package
   ansible.builtin.include_tasks: install.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Set OS related variables
+  ansible.builtin.include_vars: "{{ _vars }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_os_family }}.yml"
+    - "defaults.yml"
+  loop_control:
+    loop_var: _vars
+
 - name: Display the cloud_localds variable
   ansible.builtin.debug:
     var:
@@ -9,6 +19,11 @@
 
 - name: Install the cloud image util package
   ansible.builtin.include_tasks: install.yml
+  run_once: true
+  args:
+    apply:
+      tags:
+        - install
   tags:
     - install
 


### PR DESCRIPTION
* Added ```run_one: true``` to only execute the installation tasks only once.
* Move "name: Set OS related variables" to main, to have the provider settings when the install phase isn't executed e.g. 
   With --skip-tags install.   
* Added ```apply tags install``` to support ```--tags install ```
* Introduced load_vars.yml to allow var loading during the main and installation tasks.


